### PR TITLE
Script modified to create data directory

### DIFF
--- a/resources/download_data.sh
+++ b/resources/download_data.sh
@@ -5,11 +5,12 @@ ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_
 ABSOLUTE_DIR=$(dirname "${ABSOLUTE_PATH}")
 
 # Extract to Agile_Data_Code_2/data/on_time_performance.parquet, wherever we are executed from
-cd $ABSOLUTE_DIR/../data/
-curl -Lko ./simple_flight_delay_features.jsonl.bz2 http://s3.amazonaws.com/agile_data_science/simple_flight_delay_features.jsonl.bz2
+cd $ABSOLUTE_DIR/..
+mkdir data
+curl -Lko ./data/simple_flight_delay_features.jsonl.bz2 http://s3.amazonaws.com/agile_data_science/simple_flight_delay_features.jsonl.bz2
 
 # Get the distances between pairs of airports
-curl -Lko ./origin_dest_distances.jsonl http://s3.amazonaws.com/agile_data_science/origin_dest_distances.jsonl
+curl -Lko ./data/origin_dest_distances.jsonl http://s3.amazonaws.com/agile_data_science/origin_dest_distances.jsonl
 
 # Get the models to make ch08/web/predict_flask.py go
 cd $ABSOLUTE_DIR/..


### PR DESCRIPTION
Hay un pequeño problema con el script de descargar los datos, ya que se intentan descargar en una carpeta que no existe y luego cuando se buscan en la carpeta pues claro, no están ahí.

Este PR soluciona esto creando la carpeta de daa previamente para evitar tener que hacerlo a mano.